### PR TITLE
Bugfix/135/add to cart issue

### DIFF
--- a/core/config.php
+++ b/core/config.php
@@ -1,7 +1,7 @@
 <?php
 
-define('APP_VERSION', '0.14.1-alpha');
-define('API_VERSION', '0.10.1-alpha');
+define('APP_VERSION', '0.14.2-alpha');
+define('API_VERSION', '0.10.2-alpha');
 
 if (!empty(getenv('ENV'))) {
   require_once('config_' . getenv('ENV') . '.php');

--- a/core/core.php
+++ b/core/core.php
@@ -55,8 +55,7 @@ function processRequests()
   if (getRequestData('action') == ACTION_ADD_TO_CART) {
     setSession('request_messages', addToCart());
     $query_str  = getQueryParams(['action' => null, 'aid' => null, 'qty' => null]);
-    $articlePage = explode('/', getServer('REQUEST_URI'), -1);
-    $redirectTo = getRequestURIPath() . (!empty($query_str) ? "?$query_str" : "") . (($articlePage[1] == 'articulo') ? ("?aid=" . getRequestData('aid')) : "");
+    $redirectTo = getRequestURIPath() . (!empty($query_str) ? "?$query_str" : '');
     header("Location: $redirectTo");
     exit;
   }

--- a/template_dev/components/header/header.php
+++ b/template_dev/components/header/header.php
@@ -1,4 +1,3 @@
-<?php logToConsole('query-string', getServer('QUERY_STRING'), __FILE__, __FUNCTION__, __LINE__) ?>
 <header>
   <div class="header-inner">
     <div class="site-nav">

--- a/template_dev/pages/search.php
+++ b/template_dev/pages/search.php
@@ -16,19 +16,7 @@ newDocument([
     'components/category/category.css'
   ],
   'beforeRender' => function () {
-    $key = getServer('REQUEST_URI');
-    $key = explode("=", $key);
-    
-    if($key[0] != '/busqueda/?clave')
-    {
-      @$key = ($key[3]);
-    }
-    else
-    {
-      $key = ($key[1]);
-    }
-
-    $key             = str_replace("+", " ", $key);
+    $key             = getQueryParamsByName(['clave'])['clave'];
     $result_articles = searchArticle($key);
     
     if($result_articles != null)


### PR DESCRIPTION
Agregué una función nueva `getQueryParamsByName($names = null)` que recibe un array de nombres y devuelve un array asociativo con los parámetros que se piden en el array de nombres, o si no se pasa ningún array, devuelve un array asociativo con todos los parámetros, así en lugar de tener que buscar manualmente, sólo tenemos que usar esta función, como en el Search.

Esta función la usé para simplificar la función `getQueryParams` que devuelve los parámetros de la url en formato QUERY_STRING, y con eso solucioné el error en la lógica que romía el paginador y el buscador.